### PR TITLE
Add serialization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 TESTS=tests/unit tests/functional
 
+.PHONY: htmlcov
+
 test:
 	py.test --cov lynk \
 	        --cov-report term-missing \

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,6 +19,16 @@ Getting Started
 
    quickstart
 
+Topics
+------
+
+.. toctree::
+   :maxdepth: 2
+   :glob:
+
+   topics/index
+
+
 Indices and tables
 ==================
 

--- a/docs/source/topics/index.rst
+++ b/docs/source/topics/index.rst
@@ -1,0 +1,4 @@
+.. toctree::
+   :maxdepth: 2
+
+   serialization

--- a/docs/source/topics/serialization.rst
+++ b/docs/source/topics/serialization.rst
@@ -47,7 +47,7 @@ operating on the protected resource. Otherwise it will raise the
 ``LockAlreadyInUseError`` to indicate that the lock was stolen between
 serialization and deserialization.
 
-..code-block:: python
+.. code-block:: python
 
    import lynk
    from lynk.exceptions import LockAlreadyInUseError

--- a/docs/source/topics/serialization.rst
+++ b/docs/source/topics/serialization.rst
@@ -1,0 +1,60 @@
+Serialization
+=============
+
+
+Overview
+--------
+
+A lock can be used to control access to some shared resource. In a serverless
+environment jobs can be broken up into many pieces often being operated on by
+a sequence of disparate functions. In order to hold a lock between these
+separate functions there needs to be a mechanism for a lock to be transfered
+between seprate processes, or passed through a queue etc.
+
+To accomodate this use case, Locks are serializable. A lock can be taken
+against a resource in one process, serialized and passed into some other
+process. The target process can then derserialize the lock and continue
+operating on the same resource as the first.
+
+
+Serialization
+-------------
+
+Lynk Locks use a simple JSON serialization scheme, to allow them to be passed
+around as plain text between processes.
+
+To serialize a Lock use the ``.serialize()`` method.
+
+.. code-block:: python
+
+   import lynk
+
+   session = lynk.get_session('lynk-quickstart')
+   lock = session.create_lock('my lock')
+   serialized_lock = lock.serialize()
+
+The ``serialized_lock`` variable is now a plain UTF-8 string that can be sent
+to another component of a complex system.
+
+
+Deserialization
+---------------
+
+A lock object can be loaded using the ``Session`` method
+``deserialize_lock()`` and passing it the ``serialzied_lock`` value from the
+previous section. If it successful the new process can now start
+operating on the protected resource. Otherwise it will raise the
+``LockAlreadyInUseError`` to indicate that the lock was stolen between
+serialization and deserialization.
+
+..code-block:: python
+
+   import lynk
+   from lynk.exceptions import LockAlreadyInUseError
+
+   try:
+       session = lynk.get_session('lynk-quickstart')
+       lock = session.deserialize_lock(serialized_lock)
+       do_stuff_with_locked_resource(lock)
+   except LockAlreadyInUseError as:
+       print("Someone else stole the lock.")

--- a/examples/serialization.py
+++ b/examples/serialization.py
@@ -1,0 +1,110 @@
+import uuid
+import time
+import threading
+import logging
+import queue
+
+import lynk
+from lynk.backends.dynamodb import DynamoDBControl
+
+
+LOG = logging.getLogger(__file__)
+THREADS = 20
+
+
+class SleepyThread(threading.Thread):
+    def __init__(self, session, input_q, output_q):
+        super(SleepyThread, self).__init__()
+        self._session = session
+        self._iq = input_q
+        self._oq = output_q
+
+    def run(self):
+        LOG.debug('Starting')
+        # Block until we get the lock in our input queue.
+        serialized_lock = self._iq.get()
+
+        # Turn into a real lock object
+        lock = self._session.deserialize_lock(serialized_lock)
+        LOG.debug('Deserialized lock')
+
+        # Do "work"
+        LOG.debug('Working...')
+        time.sleep(1)
+
+        # Serialize the lock to pass to next thread
+        serialized_lock = lock.serialize()
+        LOG.debug('Serialized lock')
+        LOG.debug('Ending')
+        self._oq.put(serialized_lock)
+
+
+def do_work_with_locks(session):
+    # Pass our session to each thread. Each thread can create its own lock
+    # instance from the shared session, ensuring they are backed by the same
+    # table.
+    lock = session.create_lock('my lock', auto_refresh=False)
+
+    # Each thread has two queues, an input queue and an output queue. These
+    # overlap by 1, so Thread-1's output queue is Thread-2's input queue.
+    # Each time a Thread is done working, it seraializes its lock and passes it
+    # to the next thread in the queue.
+    Qs = [queue.Queue() for _ in range(THREADS + 1)]
+    threads = [SleepyThread(session, Qs[i], Qs[i+1]) for i in range(THREADS)]
+
+    for t in threads:
+        t.start()
+
+    # Acquire the lock and pass the serialized lock to the first thread.
+    LOG.debug("Sending lock to first thread.")
+    lock.acquire()
+    serialized_lock = lock.serialize()
+    Qs[0].put(serialized_lock)
+
+    # Wait on the last Queue to get the lock back.
+    serialized_lock = Qs[-1].get()
+
+    LOG.debug("Got lock back.")
+
+    # Release the lock and ensure the threads are done.
+    lock = session.deserialize_lock(serialized_lock)
+    lock.release()
+
+    for t in threads:
+        t.join()
+
+
+def main():
+    # Instantiate a default Session with our table name. By default the
+    # Session uses DynamoDB as a backend to store lock information. This
+    # means our lock objects can be spread across multiple machines, as long as
+    # they are using the same AWS creds, table name for the backend, and lock
+    # name, they will work the same as shown here in threads.
+    table_name = 'example-lynk-basic-table-%s' % str(uuid.uuid4())
+    session = lynk.get_session(table_name)
+    # Create a DynamoDBControl object to give us access to the control plane
+    # of dynamodb for creation/deletion of tables. For this example we create
+    # a table if needed, and destroy it after running the example.
+    control = DynamoDBControl(table_name)
+    try:
+        if not control.exists():
+            LOG.debug('Creating table %s', table_name)
+            control.create()
+        do_work_with_locks(session)
+    finally:
+        LOG.debug('Destroying table %s', table_name)
+        control.destroy()
+
+
+def configure_logging():
+    # Configure logging so we can see which thread is doing what.
+    LOG.setLevel(logging.DEBUG)
+    formatter = logging.Formatter('%(asctime)s - %(threadName)s - %(message)s')
+    ch = logging.StreamHandler()
+    ch.setFormatter(formatter)
+    LOG.addHandler(ch)
+
+
+if __name__ == '__main__':
+    configure_logging()
+    main()

--- a/src/lynk/exceptions.py
+++ b/src/lynk/exceptions.py
@@ -24,3 +24,9 @@ class LockLostError(Exception):
 
 class NoSuchLockError(Exception):
     """Raised when an operation is performed on a non-existant lock."""
+
+
+class CannotDeserializeError(Exception):
+    """Raised when something cannot be deserialized."""
+    def __init__(self, reason):
+        self.message = reason

--- a/src/lynk/lock.py
+++ b/src/lynk/lock.py
@@ -1,3 +1,5 @@
+import json
+
 from contextlib import contextmanager
 
 
@@ -85,3 +87,22 @@ class Lock(object):
             return
         self._refresher.stop()
         self._refresher = None
+
+    def serialize(self):
+        """Serialize this lock to a UTF-8 string.
+
+        To restore the string to a lock object, construct a session object
+        that matches the one that this lock was constructed with. Call its
+        :method:`lynk.session.Session.deserialize_lock` method.
+
+        To improve its chances of making the journey to the new host with
+        ownership of the lock entry in the remote table, the Lock calls it's
+        own :meth:`lynk.lock.Lock.refresh` method.
+        """
+        properties = {
+            '__version': '%s.1' % self.__class__.__name__,
+            'name': self._name,
+            'technique': self._technique.serialize(),
+        }
+        self.refresh()
+        return json.dumps(properties)

--- a/src/lynk/lock.py
+++ b/src/lynk/lock.py
@@ -99,10 +99,11 @@ class Lock(object):
         ownership of the lock entry in the remote table, the Lock calls it's
         own :meth:`lynk.lock.Lock.refresh` method.
         """
+        self._stop_refresher()
+        self.refresh()
         properties = {
             '__version': '%s.1' % self.__class__.__name__,
             'name': self._name,
             'technique': self._technique.serialize(),
         }
-        self.refresh()
         return json.dumps(properties)

--- a/src/lynk/lock.py
+++ b/src/lynk/lock.py
@@ -93,7 +93,7 @@ class Lock(object):
 
         To restore the string to a lock object, construct a session object
         that matches the one that this lock was constructed with. Call its
-        :method:`lynk.session.Session.deserialize_lock` method.
+        :meth:`lynk.session.Session.deserialize_lock` method.
 
         To improve its chances of making the journey to the new host with
         ownership of the lock entry in the remote table, the Lock calls it's

--- a/src/lynk/techniques.py
+++ b/src/lynk/techniques.py
@@ -137,7 +137,6 @@ class VersionLeaseTechinque(BaseTechnique):
                                   backend, host_identifier=None,
                                   time_utils=None):
         data = json.loads(serialized_technique)
-        print(data)
         version = data.get('__version')
         if not version:
             raise CannotDeserializeError(
@@ -327,4 +326,5 @@ class VersionLeaseTechinque(BaseTechnique):
             '__version': '%s.1' % self.__class__.__name__,
             'versions': self._versions,
         }
-        return json.dumps(properties)
+        serialized = json.dumps(properties)
+        return serialized

--- a/tests/unit/test_lock.py
+++ b/tests/unit/test_lock.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 import mock
 
@@ -26,6 +28,17 @@ def create_lock():
 
 
 class TestLock(object):
+    def test_can_serialize_lock(self, create_lock):
+        lock, tech, _ = create_lock(name='foo')
+        tech.serialize.return_value = 'SERIALIZED_TECHNIQUE'
+        serial = json.loads(lock.serialize())
+
+        assert serial == {
+            '__version': 'Lock.1',
+            'name': 'foo',
+            'technique': 'SERIALIZED_TECHNIQUE',
+        }
+
     def test_can_acquire_lock(self, create_lock):
         lock, tech, _ = create_lock()
         lock.acquire()

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -1,8 +1,12 @@
+import json
+
+import pytest
 import mock
 
 import lynk
 from lynk.session import Session
 from lynk.lock import Lock
+from lynk.exceptions import CannotDeserializeError
 
 
 class TestSession(object):
@@ -40,3 +44,123 @@ class TestSession(object):
         # No other easy way to check this without a real backend. So for a
         # simple unit test we will reach into the private varaible to check.
         assert lock._refresher_factory is None
+
+    def test_can_deserialize_lock(self):
+        bridge_factory = mock.Mock()
+        mock_bridge = mock.Mock()
+        mock_backend = mock.Mock()
+        bridge_factory.create.return_value = (mock_bridge, mock_backend)
+        session = Session(
+            'table_name',
+            backend_bridge_factory=bridge_factory,
+        )
+        serialized_lock = json.dumps({
+            '__version': 'Lock.1',
+            'name': 'foo',
+            'technique': (
+                '{"__version": "VersionLeaseTechinque.1", '
+                '"versions": {"foo": "version-identifier"}}'
+            ),
+        })
+        lock = session.deserialize_lock(serialized_lock)
+        assert isinstance(lock, Lock)
+
+        # Ensure that the lock tried to refresh itself asap after being
+        # deserialized since we don't know how much time has gone by.
+        mock_bridge.we_own_lock.assert_called_with('version-identifier')
+        mock_backend.update.assert_called_with(
+            {'lockKey': 'foo'},
+            condition=mock.ANY,
+            updates=mock.ANY,
+        )
+
+    def test_can_deserialize_lock_without_auto_refresher(self):
+        bridge_factory = mock.Mock()
+        mock_bridge = mock.Mock()
+        mock_backend = mock.Mock()
+        bridge_factory.create.return_value = (mock_bridge, mock_backend)
+        session = Session(
+            'table_name',
+            backend_bridge_factory=bridge_factory,
+        )
+        serialized_lock = json.dumps({
+            '__version': 'Lock.1',
+            'name': 'foo',
+            'technique': (
+                '{"__version": "VersionLeaseTechinque.1", '
+                '"versions": {"foo": "version-identifier"}}'
+            ),
+        })
+        lock = session.deserialize_lock(serialized_lock, auto_refresh=False)
+        assert isinstance(lock, Lock)
+
+        mock_bridge.we_own_lock.assert_called_with('version-identifier')
+        mock_backend.update.assert_called_with(
+            {'lockKey': 'foo'},
+            condition=mock.ANY,
+            updates=mock.ANY,
+        )
+
+    def test_does_raise_on_invalid_lock(self):
+        bridge_factory = mock.Mock()
+        mock_bridge = mock.Mock()
+        mock_backend = mock.Mock()
+        bridge_factory.create.return_value = (mock_bridge, mock_backend)
+        session = Session(
+            'table_name',
+            backend_bridge_factory=bridge_factory,
+        )
+        serialized_lock = json.dumps({})
+
+        with pytest.raises(CannotDeserializeError):
+            session.deserialize_lock(serialized_lock, auto_refresh=False)
+
+    def test_does_raise_on_wrong_serialized_version(self):
+        bridge_factory = mock.Mock()
+        mock_bridge = mock.Mock()
+        mock_backend = mock.Mock()
+        bridge_factory.create.return_value = (mock_bridge, mock_backend)
+        session = Session(
+            'table_name',
+            backend_bridge_factory=bridge_factory,
+        )
+        serialized_lock = json.dumps({
+            '__version': 'Lock.2',
+        })
+
+        with pytest.raises(CannotDeserializeError):
+            session.deserialize_lock(serialized_lock, auto_refresh=False)
+
+    def test_does_raise_on_missing_name(self):
+        bridge_factory = mock.Mock()
+        mock_bridge = mock.Mock()
+        mock_backend = mock.Mock()
+        bridge_factory.create.return_value = (mock_bridge, mock_backend)
+        session = Session(
+            'table_name',
+            backend_bridge_factory=bridge_factory,
+        )
+        serialized_lock = json.dumps({
+            '__version': 'Lock.1',
+            'name': 'Some name',
+        })
+
+        with pytest.raises(CannotDeserializeError):
+            session.deserialize_lock(serialized_lock, auto_refresh=False)
+
+    def test_does_raise_on_missing_technique(self):
+        bridge_factory = mock.Mock()
+        mock_bridge = mock.Mock()
+        mock_backend = mock.Mock()
+        bridge_factory.create.return_value = (mock_bridge, mock_backend)
+        session = Session(
+            'table_name',
+            backend_bridge_factory=bridge_factory,
+        )
+        serialized_lock = json.dumps({
+            '__version': 'Lock.1',
+            'technique': '...',
+        })
+
+        with pytest.raises(CannotDeserializeError):
+            session.deserialize_lock(serialized_lock, auto_refresh=False)


### PR DESCRIPTION
Add the ability for a Lock object to be serialized down to a plain
UTF-8 string (JSON encoded). This lets it easily be passed between
systems.

Add the ability for a Session object to deserialize a serialized lock
and render it into a usable Lock. This requires that the technique and
backend used by the Session are the same as the ones that originally
were used to construct the lock.