### PR TITLE
Version bump 0.3.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 CHANGELOG
 =========
 
+0.3.1
+=====
+
+Update host idenitifer when refreshing lock.
+(`#5 <https://github.com/stealthycoin/lynk/pull/5>`__)
+
+
 0.3.0
 =====
 

--- a/src/lynk/__init__.py
+++ b/src/lynk/__init__.py
@@ -1,6 +1,6 @@
 from lynk.session import Session
 
-__version__ = '0.3.0'
+__version__ = '0.3.1'
 
 
 def get_session(table_name, host_identifier=None,

--- a/src/lynk/techniques.py
+++ b/src/lynk/techniques.py
@@ -308,6 +308,7 @@ class VersionLeaseTechinque(BaseTechnique):
             self._backend.update(
                 {'lockKey': name},
                 updates={
+                    'hostIdentifier': self._host_identifier,
                     'versionNumber': new_version,
                 },
                 condition=self._backend_bridge.we_own_lock(old_version),

--- a/tests/unit/test_techniques.py
+++ b/tests/unit/test_techniques.py
@@ -116,14 +116,17 @@ class TestVersionLeaseTechnique(object):
         )
 
     def test_can_refresh_lock(self, version_lease_factory):
-        vlt, bridge, backend, _ = version_lease_factory()
+        vlt, bridge, backend, _ = version_lease_factory(host='host-ident')
         vlt.acquire('lock name', 5, 200)
         vlt.refresh('lock name')
         version = backend.put.call_args_list[0][0][0]['versionNumber']
         backend.update.assert_called_with(
             {'lockKey': 'lock name'},
             condition=mock.ANY,
-            updates={'versionNumber': mock.ANY},
+            updates={
+                'versionNumber': mock.ANY,
+                'hostIdentifier': 'host-ident',
+            },
         )
         bridge.we_own_lock.assert_called_with(version)
 


### PR DESCRIPTION
Update the host identifier on refresh. Now that locks can travel
between hosts by serialization and deserialization, when they refresh
on deserialization the host identifier should be updated to reflect
their new host.